### PR TITLE
Validation issue for custom schemas

### DIFF
--- a/scimono-server/src/main/java/com/sap/scimono/entity/schema/validation/SchemaIdValidator.java
+++ b/scimono-server/src/main/java/com/sap/scimono/entity/schema/validation/SchemaIdValidator.java
@@ -2,7 +2,6 @@
 package com.sap.scimono.entity.schema.validation;
 
 import com.sap.scimono.callback.schemas.SchemasCallback;
-import com.sap.scimono.entity.schema.Schema;
 
 import javax.validation.ConstraintValidator;
 import javax.validation.ConstraintValidatorContext;
@@ -13,7 +12,7 @@ public class SchemaIdValidator implements ConstraintValidator<ValidSchemaId, Str
 
   @Override
   public boolean isValid(String schemaId, ConstraintValidatorContext context) {
-    return isValidSchemaId(schemaId, context) && isValidIdentifierName(schemaId.substring(Schema.EXTENSION_SCHEMA_URN.length()), context);
+    return isValidSchemaId(schemaId, context) && isValidIdentifierName(schemaId, context);
   }
 
   private boolean isValidSchemaId(final String schemaId, ConstraintValidatorContext context) {
@@ -26,7 +25,12 @@ public class SchemaIdValidator implements ConstraintValidator<ValidSchemaId, Str
     return false;
   }
 
-  private boolean isValidIdentifierName(final String identifierName, ConstraintValidatorContext context) {
+  private boolean isValidIdentifierName(final String schemaUrn, ConstraintValidatorContext context) {
+    final int indexOfSchemaDelimiter = schemaUrn.lastIndexOf(SchemasCallback.SCHEMA_URN_DELIMETER);
+    if (indexOfSchemaDelimiter == -1) {
+      return false;
+    }
+    final String identifierName = schemaUrn.substring(indexOfSchemaDelimiter + 1);
     return isAlphanumeric(identifierName) && isIdenifierLenghtValid(identifierName, context);
 
   }

--- a/scimono-server/src/main/java/com/sap/scimono/entity/schema/validation/SchemaValidator.java
+++ b/scimono-server/src/main/java/com/sap/scimono/entity/schema/validation/SchemaValidator.java
@@ -5,7 +5,7 @@ import java.util.List;
 
 import javax.validation.ConstraintValidator;
 import javax.validation.ConstraintValidatorContext;
-
+import com.sap.scimono.callback.schemas.SchemasCallback;
 import com.sap.scimono.entity.schema.Attribute;
 import com.sap.scimono.entity.schema.Schema;
 
@@ -72,7 +72,11 @@ class SchemaValidator implements ConstraintValidator<ValidSchema, Schema> {
       return true;
     }
 
-    if (schema.getName().equals(schema.getId().substring(Schema.EXTENSION_SCHEMA_URN.length()))) {
+    final int indexOfSchemaDelimiter = schema.getId().lastIndexOf(SchemasCallback.SCHEMA_URN_DELIMETER);
+    if (indexOfSchemaDelimiter == -1) {
+      return true;
+    }
+    if (schema.getName().equals(schema.getId().substring(indexOfSchemaDelimiter + 1))) {
       ValidationUtil.interpolateErrorMessage(context, "Schema name and id does not match!");
 
       return true;


### PR DESCRIPTION
Validation for custom schema with a name that does not start with "urn:sap:cloud:scim:schemas:extension:custom:2.0:" is incorrect.