### PR TITLE
[access-token-auth]: Support using an access token as a workaround wh…

### DIFF
--- a/scimono-client/src/main/java/com/sap/scimono/client/authentication/TargetSystemAccessTokenAuthenticator.java
+++ b/scimono-client/src/main/java/com/sap/scimono/client/authentication/TargetSystemAccessTokenAuthenticator.java
@@ -1,0 +1,26 @@
+package com.sap.scimono.client.authentication;
+
+import javax.xml.bind.DatatypeConverter;
+import java.nio.charset.StandardCharsets;
+
+public class TargetSystemAccessTokenAuthenticator implements TargetSystemAuthenticator {
+  private final String accessToken;
+
+  private TargetSystemAccessTokenAuthenticator(final String accessToken) {
+    this.accessToken = accessToken;
+  }
+
+  public static TargetSystemAuthenticator.Builder<TargetSystemAccessTokenAuthenticator> create(String accessToken) {
+    return new Builder<TargetSystemAccessTokenAuthenticator>() {
+      @Override
+      public TargetSystemAccessTokenAuthenticator build() {
+        return new TargetSystemAccessTokenAuthenticator(accessToken);
+      }
+    };
+  }
+
+  @Override
+  public String authenticate() {
+    return "Bearer " + DatatypeConverter.printBase64Binary(accessToken.getBytes(StandardCharsets.UTF_8));
+  }
+}

--- a/scimono-compliance-tests/Readme.md
+++ b/scimono-compliance-tests/Readme.md
@@ -43,6 +43,15 @@ Values for the following command line arguments: `oauth.clientId`;  `oauth.secre
 java -jar scimono-compliance-tests-${version}-shaded.jar scim.service.url=http://localhost:8080/scim/v2 auth.type=Oauth oauth.grant=client_credentials oauth.clientId=admin oauth.secret=secret oauth.service.url=http://localhost:8080/oauth/token
 ```
 
+### Bearer Access Token Authentication
+
+If you would like to use an access token retrieved by an OAuth grant that is not directly supported by this library, you can simply pass in a valid access token that will be prefixed with `Bearer` and included in the Authorization header of the SCIM requests.   
+
+Values for the command line arguments  `bearer.token` must be provided alongside with `auth.type=Token` parameter. For example:
+```
+java -jar scimono-compliance-tests-${version}-shaded.jar scim.service.url=http://localhost:8080/scim/v2 auth.type=Token access.token=<access_token>
+```
+
 ## Run custom tests
 
 Many of the SCIM 2.0 service providers implement only some of the SCIM 2.0 features. It is possible to execute subset of all tests that are provided. You can specify which tests to be included in the test execution in `.csv` file with the following format:

--- a/scimono-compliance-tests/src/main/java/com/sap/scimono/scim/system/tests/SCIMComplianceTest.java
+++ b/scimono-compliance-tests/src/main/java/com/sap/scimono/scim/system/tests/SCIMComplianceTest.java
@@ -1,14 +1,7 @@
 package com.sap.scimono.scim.system.tests;
 
 import static com.sap.scimono.client.authentication.OauthAuthenticatorFactory.clientCredentialsGrantAuthenticator;
-import static com.sap.scimono.scim.system.tests.util.TestProperties.AUTH_TYPE;
-import static com.sap.scimono.scim.system.tests.util.TestProperties.BASIC_AUTH_PASSWORD;
-import static com.sap.scimono.scim.system.tests.util.TestProperties.BASIC_AUTH_USER;
-import static com.sap.scimono.scim.system.tests.util.TestProperties.OAUTH_CLIENT_ID;
-import static com.sap.scimono.scim.system.tests.util.TestProperties.OAUTH_GRANT;
-import static com.sap.scimono.scim.system.tests.util.TestProperties.OAUTH_SECRET;
-import static com.sap.scimono.scim.system.tests.util.TestProperties.OAUTH_SERVICE_URL;
-import static com.sap.scimono.scim.system.tests.util.TestProperties.SERVICE_URL;
+import static com.sap.scimono.scim.system.tests.util.TestProperties.*;
 import static com.sap.scimono.scim.system.tests.util.TestUtil.constructResourceLocation;
 import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -27,6 +20,7 @@ import javax.ws.rs.client.ClientBuilder;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.UriBuilder;
 
+import com.sap.scimono.client.authentication.*;
 import com.sap.scimono.entity.paging.PagedByIndexSearchResult;
 import org.glassfish.jersey.client.HttpUrlConnectorProvider;
 import org.glassfish.jersey.logging.LoggingFeature;
@@ -39,10 +33,6 @@ import com.sap.scimono.client.SCIMClientService;
 import com.sap.scimono.client.SCIMResponse;
 import com.sap.scimono.client.SchemaRequest;
 import com.sap.scimono.client.UserRequest;
-import com.sap.scimono.client.authentication.OauthCredentials;
-import com.sap.scimono.client.authentication.OauthDeviceIdAuthenticator;
-import com.sap.scimono.client.authentication.TargetSystemAuthenticator;
-import com.sap.scimono.client.authentication.TargetSystemBasicAuthenticator;
 import com.sap.scimono.entity.Group;
 import com.sap.scimono.entity.Meta;
 import com.sap.scimono.entity.Resource;
@@ -65,6 +55,8 @@ public abstract class SCIMComplianceTest {
       targetSystemAuthenticator = TargetSystemBasicAuthenticator.create(BASIC_AUTH_USER, BASIC_AUTH_PASSWORD);
     } else if ("Oauth".equalsIgnoreCase(AUTH_TYPE)) {
       targetSystemAuthenticator = getOauthAuthenticatorBuilder();
+    } else if ("Token".equalsIgnoreCase(AUTH_TYPE)) {
+      targetSystemAuthenticator = TargetSystemAccessTokenAuthenticator.create(ACCESS_TOKEN);
     }
   }
 

--- a/scimono-compliance-tests/src/main/java/com/sap/scimono/scim/system/tests/util/TestProperties.java
+++ b/scimono-compliance-tests/src/main/java/com/sap/scimono/scim/system/tests/util/TestProperties.java
@@ -10,6 +10,8 @@ public class TestProperties {
   public static final String BASIC_AUTH_USER = System.getProperty("basic.auth.user");
   public static final String BASIC_AUTH_PASSWORD = System.getProperty("basic.auth.password");
 
+  public static final String ACCESS_TOKEN = System.getProperty("access.token");
+
   public static final String INTEGRATION_TESTS_HOST = "integration.test.server.url";
   public static final String SERVICE_URL = System.getProperty("scim.service.url");
 


### PR DESCRIPTION
…en API's OAuth grants are not supported by the simono library