### PR TITLE
SCI-35172: Always return userName as part of min SCIM User representation

### DIFF
--- a/scimono-server/src/main/java/com/sap/scimono/entity/User.java
+++ b/scimono-server/src/main/java/com/sap/scimono/entity/User.java
@@ -219,6 +219,7 @@ public final class User extends Resource<User> {
    *
    * @return the user name
    */
+  @JsonInclude(Include.ALWAYS)
   public String getUserName() {
     return userName;
   }


### PR DESCRIPTION
https://datatracker.ietf.org/doc/html/rfc7643#section-8.1
According to the recommended example of the minimal required SCIM representation in JSON format, the "userName" attribute should always be returned.

- _Expected behavior: User resource is returned and userName attribute is present, even in the cases where it is equal to ""_ ;