### PR TITLE
Fix location in update

### DIFF
--- a/scimono-server/src/main/java/com/sap/scimono/api/Groups.java
+++ b/scimono-server/src/main/java/com/sap/scimono/api/Groups.java
@@ -164,7 +164,9 @@ public class Groups {
     Group preparedGroup = groupPreProcessor.prepareForUpdate(groupToUpdate, groupId);
 
     Group updatedGroup = groupAPI.updateGroup(preparedGroup);
+
     updatedGroup = resourceLocationService.addMembersLocation(updatedGroup);
+    updatedGroup = resourceLocationService.addLocation(updatedGroup, updatedGroup.getId());
 
     String version = preparedGroup.getMeta().getVersion();
     logger.trace("Updated group {}, new version is {}", groupId, version);

--- a/scimono-server/src/main/java/com/sap/scimono/api/Users.java
+++ b/scimono-server/src/main/java/com/sap/scimono/api/Users.java
@@ -190,6 +190,8 @@ public class Users {
     User preparedUser = userPreProcessor.prepareForUpdate(userToUpdate, userId);
 
     User updatedUser = usersAPI.updateUser(preparedUser);
+
+    updatedUser = resourceLocationService.addLocation(updatedUser, updatedUser.getId());
     updatedUser = resourceLocationService.addRelationalEntitiesLocation(updatedUser);
 
     String version = preparedUser.getMeta().getVersion();


### PR DESCRIPTION
If resourceAPI.updateResource(resourceToUpdate) returns a different resource from the passed resourceToUpdate argument, the location attribute is not set.