### PR TITLE
SCI-36497: Allow schema

### DIFF
--- a/scimono-server/src/main/java/com/sap/scimono/entity/validation/patch/PatchValidationFramework.java
+++ b/scimono-server/src/main/java/com/sap/scimono/entity/validation/patch/PatchValidationFramework.java
@@ -119,9 +119,10 @@ public class PatchValidationFramework {
 
   public static PatchValidationFramework groupsFramework(final SchemasCallback schemaAPI, final ResourceTypesCallback resourceTypesAPI) {
     String coreSchemaId = Group.SCHEMA;
+    String customExtensionSchemaId = Schema.EXTENSION_SCHEMA_URN + Group.RESOURCE_TYPE_GROUP;
     String resourceType = Group.RESOURCE_TYPE_GROUP;
 
-    Map<String, Schema> requiredSchemas = getRequiredSchemas(schemaAPI, Collections.singleton(coreSchemaId));
+    Map<String, Schema> requiredSchemas = getRequiredSchemas(schemaAPI, new HashSet<String>(Arrays.asList(coreSchemaId, customExtensionSchemaId)));
     return new PatchValidationFramework(schemaAPI, resourceTypesAPI, requiredSchemas, coreSchemaId, resourceType);
   }
 


### PR DESCRIPTION
"urn:sap:cloud:scim:schemas:extension:custom:2.0:Group" in Group patch
validation framework