### PR TITLE
Fix flakiness due to indeterminate HashMap orderings in unit test

### DIFF
--- a/scimono-client/src/main/java/com/sap/scimono/client/query/ResourcePageQuery.java
+++ b/scimono-client/src/main/java/com/sap/scimono/client/query/ResourcePageQuery.java
@@ -1,6 +1,6 @@
 package com.sap.scimono.client.query;
 
-import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.Map;
 
 import javax.ws.rs.client.WebTarget;
@@ -10,7 +10,7 @@ public class ResourcePageQuery implements SCIMQuery {
   private static final long DEFAULT_START_INDEX = 1;
   private static final String DEFAULT_START_ID = "00000000-0000-1000-9000-000000000000";
 
-  private final Map<String, Object> queryParams = new HashMap<>();
+  private final Map<String, Object> queryParams = new LinkedHashMap<>();
 
   ResourcePageQuery() {
   }

--- a/scimono-client/src/test/java/com/sap/scimono/client/ResourcePageQueryTest.java
+++ b/scimono-client/src/test/java/com/sap/scimono/client/ResourcePageQueryTest.java
@@ -7,7 +7,7 @@ import org.junit.jupiter.api.Test;
 import javax.ws.rs.client.ClientBuilder;
 import javax.ws.rs.client.WebTarget;
 
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class ResourcePageQueryTest {
   private static final String DEFAULT_URL = "http://localhost:7070/idds/scim/v2/Users";
@@ -21,15 +21,13 @@ public class ResourcePageQueryTest {
   @Test
   public void testCreateDefaultIndexFilter() {
     String resultRequestPath = ResourcePageQuery.indexPageQuery().apply(webTarget).getUri().toString();
-    assertTrue((DEFAULT_URL + "?startIndex=1&count=100").equals(resultRequestPath)
-                || (DEFAULT_URL + "?count=100&startIndex=1").equals(resultRequestPath));
+    assertEquals(DEFAULT_URL + "?startIndex=1&count=100", resultRequestPath);
   }
 
   @Test
   public void testCreateDefaultIdentityFilter() {
     String resultRequestPath = ResourcePageQuery.identityPageQuery().apply(webTarget).getUri().toString();
-    assertTrue((DEFAULT_URL + "?startId=00000000-0000-1000-9000-000000000000&count=100").equals(resultRequestPath)
-                || (DEFAULT_URL + "?count=100&startId=00000000-0000-1000-9000-000000000000").equals(resultRequestPath));
+    assertEquals(DEFAULT_URL + "?startId=00000000-0000-1000-9000-000000000000&count=100", resultRequestPath);
   }
 
   @Test
@@ -38,8 +36,7 @@ public class ResourcePageQueryTest {
     int count = 50;
 
     String resultRequestPath = ResourcePageQuery.indexPageQuery().withStartIndex(startIndex).withCount(count).apply(webTarget).getUri().toString();
-    assertTrue((String.format("%s?startIndex=%d&count=%d", DEFAULT_URL, startIndex, count)).equals(resultRequestPath)
-                || (String.format("%s?count=%d&startIndex=%d", DEFAULT_URL, count, startIndex)).equals(resultRequestPath));
+    assertEquals(String.format("%s?startIndex=%d&count=%d", DEFAULT_URL, startIndex, count), resultRequestPath);
   }
 
   @Test
@@ -48,7 +45,6 @@ public class ResourcePageQueryTest {
     int count = 50;
 
     String resultRequestPath = ResourcePageQuery.identityPageQuery().withStartId(startId).withCount(count).apply(webTarget).getUri().toString();
-    assertTrue((String.format("%s?startId=%s&count=%d", DEFAULT_URL, startId, count)).equals(resultRequestPath)
-                || (String.format("%s?count=%d&startId=%s", DEFAULT_URL, count, startId)).equals(resultRequestPath));
+    assertEquals(String.format("%s?startId=%s&count=%d", DEFAULT_URL, startId, count), resultRequestPath);
   }
 }

--- a/scimono-client/src/test/java/com/sap/scimono/client/ResourcePageQueryTest.java
+++ b/scimono-client/src/test/java/com/sap/scimono/client/ResourcePageQueryTest.java
@@ -7,7 +7,7 @@ import org.junit.jupiter.api.Test;
 import javax.ws.rs.client.ClientBuilder;
 import javax.ws.rs.client.WebTarget;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class ResourcePageQueryTest {
   private static final String DEFAULT_URL = "http://localhost:7070/idds/scim/v2/Users";
@@ -21,13 +21,15 @@ public class ResourcePageQueryTest {
   @Test
   public void testCreateDefaultIndexFilter() {
     String resultRequestPath = ResourcePageQuery.indexPageQuery().apply(webTarget).getUri().toString();
-    assertEquals(DEFAULT_URL + "?startIndex=1&count=100", resultRequestPath);
+    assertTrue((DEFAULT_URL + "?startIndex=1&count=100").equals(resultRequestPath)
+                || (DEFAULT_URL + "?count=100&startIndex=1").equals(resultRequestPath));
   }
 
   @Test
   public void testCreateDefaultIdentityFilter() {
     String resultRequestPath = ResourcePageQuery.identityPageQuery().apply(webTarget).getUri().toString();
-    assertEquals(DEFAULT_URL + "?startId=00000000-0000-1000-9000-000000000000&count=100", resultRequestPath);
+    assertTrue((DEFAULT_URL + "?startId=00000000-0000-1000-9000-000000000000&count=100").equals(resultRequestPath)
+                || (DEFAULT_URL + "?count=100&startId=00000000-0000-1000-9000-000000000000").equals(resultRequestPath));
   }
 
   @Test
@@ -36,7 +38,8 @@ public class ResourcePageQueryTest {
     int count = 50;
 
     String resultRequestPath = ResourcePageQuery.indexPageQuery().withStartIndex(startIndex).withCount(count).apply(webTarget).getUri().toString();
-    assertEquals(String.format("%s?startIndex=%d&count=%d", DEFAULT_URL, startIndex, count), resultRequestPath);
+    assertTrue((String.format("%s?startIndex=%d&count=%d", DEFAULT_URL, startIndex, count)).equals(resultRequestPath)
+                || (String.format("%s?count=%d&startIndex=%d", DEFAULT_URL, count, startIndex)).equals(resultRequestPath));
   }
 
   @Test
@@ -45,6 +48,7 @@ public class ResourcePageQueryTest {
     int count = 50;
 
     String resultRequestPath = ResourcePageQuery.identityPageQuery().withStartId(startId).withCount(count).apply(webTarget).getUri().toString();
-    assertEquals(String.format("%s?startId=%s&count=%d", DEFAULT_URL, startId, count), resultRequestPath);
+    assertTrue((String.format("%s?startId=%s&count=%d", DEFAULT_URL, startId, count)).equals(resultRequestPath)
+                || (String.format("%s?count=%d&startId=%s", DEFAULT_URL, count, startId)).equals(resultRequestPath));
   }
 }


### PR DESCRIPTION
**Description**
Several (11 in total) flaky tests are found using Nondex when running commands 
```mvn edu.illinois:nondex-maven-plugin:1.1.2:nondex``` under `scimono-client` directory. All test flakinesses are due to the function `ResourcePageQuery.apply()`, which uses the default iterator of a `HashMap.entrySet()` when iterating through entries of the HashMap `queryParams`. However, an entry set for a normal HashMap is an unordered set, so it does not preserve element orders. As a result, the query parameters may not be retrieved in insertion order. This can lead to unexpected resultant URL, failure to get a `PagedByIdentitySearchResult` from a `SCIMResponse`, etc.
For example, consider `testCreateCustomIdentityFilter()` in `ResourcePageQueryTest.java` , the String `resultRequestPath` can be `http://localhost:7070/idds/scim/v2/Users?startId=00000000-0000-1000-9000-000000000000&count=50` in one run and then `http://localhost:7070/idds/scim/v2/Users?count=50&startId=00000000-0000-1000-9000-000000000000` in another.
For another example, `testReadGroupsWithIndexPagedResponse()` in `GroupRequestTest.java` may occasionally throw an `javax.ws.rs.WebApplicationException` after executing line 214 for the same reason.

**Reasons for Fixing** 
These unit tests may fail nondeterministically when been run in a different OS or when using older / future versions of Java.

**Fixes**
Using `LinkedHashMap` instead of `HashMap` to ensure determinate iteration order.