### PR TITLE
SCI-36783: Fix NPE due to null JsonNode values

### DIFF
--- a/scimono-server/src/main/java/com/sap/scimono/entity/bulk/RequestOperation.java
+++ b/scimono-server/src/main/java/com/sap/scimono/entity/bulk/RequestOperation.java
@@ -10,6 +10,7 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.NullNode;
 import com.sap.scimono.api.API;
 import com.sap.scimono.entity.ErrorResponse;
 import com.sap.scimono.entity.Group;
@@ -40,7 +41,7 @@ public class RequestOperation extends BulkOperation {
                        @JsonProperty(DATA_FIELD) final JsonNode data) {
     super(method, bulkId, version);
     this.path = path;
-    this.rawData = data;
+    this.rawData = data == null ? NullNode.getInstance() : data;
   }
 
   private RequestOperation(final Builder builder) {

--- a/scimono-server/src/main/java/com/sap/scimono/entity/patch/PatchOperation.java
+++ b/scimono-server/src/main/java/com/sap/scimono/entity/patch/PatchOperation.java
@@ -6,6 +6,7 @@ import static com.sap.scimono.helper.Strings.isNullOrEmpty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.NullNode;
 import com.sap.scimono.entity.base.MultiValuedAttributeType;
 
 public class PatchOperation {
@@ -22,7 +23,7 @@ public class PatchOperation {
       @JsonProperty("value") final JsonNode value) {
     this.op = op;
     this.path = path;
-    this.value = value;
+    this.value = value == null ? NullNode.getInstance() : value;
   }
 
   private PatchOperation(final Builder builder) {


### PR DESCRIPTION
- in previous versions of jackson the field was deserialized as NullNode and not null