### PR TITLE
SCI-37455: Fix NPE due to missing attribute name

### DIFF
--- a/scimono-server/src/main/java/com/sap/scimono/entity/validation/SchemaBasedAttributeValueValidator.java
+++ b/scimono-server/src/main/java/com/sap/scimono/entity/validation/SchemaBasedAttributeValueValidator.java
@@ -1,11 +1,6 @@
-
 package com.sap.scimono.entity.validation;
 
-import java.util.Iterator;
-import java.util.LinkedList;
-import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 
 import javax.ws.rs.core.Response;
 
@@ -31,93 +26,52 @@ public class SchemaBasedAttributeValueValidator implements Validator<Object> {
   @Override
   public void validate(final Object value) {
     JsonNode jsonNodeValue = (value instanceof JsonNode) ? (JsonNode) value : new ObjectMapper().valueToTree(value);
-    validateValueAttributes(attributeDefinition, jsonNodeValue);
+    validate(attributeDefinition, jsonNodeValue);
   }
 
-  private void validateValueAttributes(final Attribute attribute, final JsonNode value) {
+  private void validate(final Attribute attribute, final JsonNode value) {
     // remove after issue https://github.com/SAP/scimono/issues/77 is fixed
     if (EnterpriseExtension.ENTERPRISE_URN.equalsIgnoreCase(attribute.getName())) {
       return;
     }
     // end of the workaround connected with https://github.com/SAP/scimono/issues/77
 
-    if (attribute.isMultiValued() && value.isArray()) {
-      // @formatter:off
-      Attribute singleValuedAttribute = new Attribute.Builder()
-          .name(attribute.getName())
-          .multiValued(false)
-          .required(false)
-          .type(attribute.getType())
-          .mutability(attribute.getMutability())
-          .addSubAttributes(attribute.getSubAttributes())
-          .build();
-      // @formatter:on
+    new AttributeDataTypeValidator(value).validate(attribute);
+    new CanonicalValuesValidator(value).validate(attribute);
 
-      for (JsonNode valueElement : value) {
-        validateValueAttributes(singleValuedAttribute, valueElement);
-      }
-    } else if (attribute.isMultiValued() && !value.isArray()) {
-      throw new SCIMException(SCIMException.Type.INVALID_SYNTAX, "Value that should be multivalued is not.", Response.Status.BAD_REQUEST);
-    } else {
-      validateAttribute(attribute, value);
-      if (AttributeDataType.COMPLEX.toString().equals(attribute.getType())) {
-        validateComplexAttribute(value, attribute.getSubAttributes());
+    if (AttributeDataType.COMPLEX.toString().equals(attribute.getType())) {
+      if (attribute.isMultiValued()) {
+        for (JsonNode valueElement : value) {
+          validateSubAttributes(attribute, valueElement);
+        }
       } else {
-        validateSimpleAttribute(value);
+        validateSubAttributes(attribute, value);
       }
     }
   }
 
-  private void validateSimpleAttribute(final JsonNode value) {
-    if (value.isContainerNode()) {
-      throw new SCIMException(SCIMException.Type.INVALID_SYNTAX, "Simple attribute cannot hava complex or multivalued value",
-          Response.Status.BAD_REQUEST);
-    }
-  }
-
-  private void validateComplexAttribute(final JsonNode value, final List<Attribute> permittedAttributes) {
-    if (!value.isObject()) {
-      throw new SCIMException(SCIMException.Type.INVALID_SYNTAX, "Value is not object.", Response.Status.BAD_REQUEST);
+  private void validateSubAttributes(final Attribute attribute, final JsonNode value) {
+    if (!SchemasCallback.isCoreSchema(attribute.getName())) {
+      new RequiredSubAttributesValidator(value).validate(attribute);
     }
 
-    Iterator<Map.Entry<String, JsonNode>> fieldsIterator = value.fields();
-    while (fieldsIterator.hasNext()) {
-      Map.Entry<String, JsonNode> field = fieldsIterator.next();
+    value.fields().forEachRemaining(field -> {
       String attrName = field.getKey();
       JsonNode attrValue = field.getValue();
 
-      // @formatter:off
-      Attribute attributeDefinition;
-      Optional<String> schemaName = permittedSchemas.keySet().stream().filter(attrName::equalsIgnoreCase).findAny();
-      if (schemaName.isPresent()) {
-        attributeDefinition = new Attribute.Builder()
-            .multiValued(false)
-            .required(false)
-            .type(AttributeDataType.COMPLEX.toString())
-            .addSubAttributes(permittedSchemas.get(schemaName.get()).getAttributes())
-            .build();
-      } else {
-        attributeDefinition = permittedAttributes.stream()
-          .filter(attr -> attrName.equalsIgnoreCase(attr.getName()))
-          .findAny()
-          .orElseThrow(() -> new SCIMException(SCIMException.Type.INVALID_SYNTAX,
-              String.format("Provided attribute with name '%s' does not exist according to the schema", attrName),
-              Response.Status.BAD_REQUEST));
+      Attribute subAttribute = attribute.getSubAttributes().stream().filter(subAttr -> attrName.equalsIgnoreCase(subAttr.getName())).findFirst()
+          .orElseGet(() -> {
+            Schema schema = permittedSchemas.get(attrName);
+            return schema == null ? null : schema.toAttribute();
+          });
+
+      if (subAttribute == null) {
+        String message = String.format("Provided attribute with name '%s' does not exist according to the schema", attrName);
+        throw new SCIMException(SCIMException.Type.INVALID_SYNTAX, message, Response.Status.BAD_REQUEST);
       }
-      // @formatter:on
 
-      validateValueAttributes(attributeDefinition, attrValue);
-    }
-  }
-
-  private void validateAttribute(final Attribute attribute, final JsonNode value) {
-    List<Validator<Attribute>> validators = new LinkedList<>();
-    validators.add(new CanonicalValuesValidator(value));
-    validators.add(new AttributeDataTypeValidator(value));
-    if (!SchemasCallback.isCoreSchema(attribute.getName())) {
-      validators.add(new RequiredSubAttributesValidator(value));
-    }
-    validators.forEach(v -> v.validate(attribute));
+      validate(subAttribute, attrValue);
+    });
   }
 
 }

--- a/scimono-server/src/test/java/com/sap/scimono/entity/validation/AttributeDataTypeValidatorTest.java
+++ b/scimono-server/src/test/java/com/sap/scimono/entity/validation/AttributeDataTypeValidatorTest.java
@@ -1,0 +1,78 @@
+package com.sap.scimono.entity.validation;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.BooleanNode;
+import com.fasterxml.jackson.databind.node.DecimalNode;
+import com.fasterxml.jackson.databind.node.IntNode;
+import com.fasterxml.jackson.databind.node.JsonNodeFactory;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.fasterxml.jackson.databind.node.TextNode;
+import com.sap.scimono.entity.schema.Attribute;
+import com.sap.scimono.exception.SCIMException;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.util.stream.Stream;
+
+import static com.sap.scimono.entity.schema.AttributeDataType.BINARY;
+import static com.sap.scimono.entity.schema.AttributeDataType.BOOLEAN;
+import static com.sap.scimono.entity.schema.AttributeDataType.COMPLEX;
+import static com.sap.scimono.entity.schema.AttributeDataType.DATE_TIME;
+import static com.sap.scimono.entity.schema.AttributeDataType.DECIMAL;
+import static com.sap.scimono.entity.schema.AttributeDataType.INTEGER;
+import static com.sap.scimono.entity.schema.AttributeDataType.REFERENCE;
+import static com.sap.scimono.entity.schema.AttributeDataType.STRING;
+import static org.junit.jupiter.api.Assertions.*;
+
+class AttributeDataTypeValidatorTest {
+
+  @ParameterizedTest(name = "Attribute: {0}")
+  @MethodSource("validData")
+  void validAttributeValues(Attribute attribute, JsonNode value) {
+    new AttributeDataTypeValidator(value).validate(attribute);
+  }
+
+  private static Stream<Arguments> validData() {
+    // @formatter:off
+    return Stream.of(
+        Arguments.of(new Attribute.Builder().type(STRING.toString()).build(), new TextNode("abc")),
+        Arguments.of(new Attribute.Builder().type(INTEGER.toString()).build(), new IntNode(0)),
+        Arguments.of(new Attribute.Builder().type(BOOLEAN.toString()).build(), BooleanNode.TRUE),
+        Arguments.of(new Attribute.Builder().type(COMPLEX.toString()).build(), new ObjectNode(null)),
+        Arguments.of(new Attribute.Builder().type(DECIMAL.toString()).build(), new DecimalNode(null)),
+        Arguments.of(new Attribute.Builder().type(REFERENCE.toString()).build(), new TextNode("http://uri.com")),
+        Arguments.of(new Attribute.Builder().type(BINARY.toString()).build(), new TextNode("FF")),
+        Arguments.of(new Attribute.Builder().type(DATE_TIME.toString()).build(), new TextNode("2011-12-03T10:15:30Z")),
+        Arguments.of(new Attribute.Builder().type(STRING.toString()).multiValued(true).build(), new ArrayNode(JsonNodeFactory.instance).add("a"))
+    );
+    // @formatter:on
+  }
+
+  @ParameterizedTest(name = "Attribute: {0}")
+  @MethodSource("invalidData")
+  void invalidAttributeValues(Attribute attribute, JsonNode value) {
+    AttributeDataTypeValidator validator = new AttributeDataTypeValidator(value);
+    assertThrows(SCIMException.class, () -> validator.validate(attribute), "Should fail");
+  }
+
+  private static Stream<Arguments> invalidData() {
+    // @formatter:off
+    return Stream.of(
+        Arguments.of(new Attribute.Builder().type(STRING.toString()).build(), new IntNode(0)),
+        Arguments.of(new Attribute.Builder().type(INTEGER.toString()).build(), new TextNode("abv")),
+        Arguments.of(new Attribute.Builder().type(BOOLEAN.toString()).build(), new TextNode("true")),
+        Arguments.of(new Attribute.Builder().type(COMPLEX.toString()).build(), new ArrayNode(null)),
+        Arguments.of(new Attribute.Builder().type(DECIMAL.toString()).build(), new TextNode("0")),
+        Arguments.of(new Attribute.Builder().type(REFERENCE.toString()).build(), new TextNode("invalid uri")),
+        Arguments.of(new Attribute.Builder().type(BINARY.toString()).build(), new TextNode("non-base64")),
+        Arguments.of(new Attribute.Builder().type(DATE_TIME.toString()).build(), new TextNode("2011-13-03T10:15:30Z")),
+        Arguments.of(new Attribute.Builder().type(DATE_TIME.toString()).build(), new IntNode(0)),
+        Arguments.of(new Attribute.Builder().type(STRING.toString()).multiValued(true).build(), new ObjectNode(null)),
+        Arguments.of(new Attribute.Builder().type(STRING.toString()).multiValued(true).build(), new ArrayNode(JsonNodeFactory.instance).add(1))
+    );
+    // @formatter:on
+  }
+
+}

--- a/scimono-server/src/test/java/com/sap/scimono/entity/validation/RequiredSubAttributesValidatorTest.java
+++ b/scimono-server/src/test/java/com/sap/scimono/entity/validation/RequiredSubAttributesValidatorTest.java
@@ -1,0 +1,41 @@
+package com.sap.scimono.entity.validation;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.JsonNodeFactory;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.fasterxml.jackson.databind.node.TextNode;
+import com.sap.scimono.entity.schema.Attribute;
+import com.sap.scimono.exception.SCIMException;
+import org.junit.jupiter.api.Test;
+
+import java.util.Collections;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class RequiredSubAttributesValidatorTest {
+
+  @Test
+  void validateIsSuccessful() {
+    Attribute attribute = new Attribute.Builder().name("parent")
+        .addSubAttribute(new Attribute.Builder().name("subAttribute").required(true).build())
+        .build();
+
+    Map<String, JsonNode> fields = Collections.singletonMap("subAttribute", new TextNode("abc"));
+    ObjectNode value = new ObjectNode(null, fields);
+
+    new RequiredSubAttributesValidator(value).validate(attribute);
+  }
+
+  @Test
+  void validateShouldFailIfRequiredAttributeIsMissing() {
+    Attribute attribute = new Attribute.Builder().name("parent")
+        .addSubAttribute(new Attribute.Builder().name("subAttribute").required(true).build())
+        .build();
+
+    JsonNode value = JsonNodeFactory.instance.objectNode();
+
+    RequiredSubAttributesValidator validator = new RequiredSubAttributesValidator(value);
+    assertThrows(SCIMException.class, () -> validator.validate(attribute), "Should fail");
+  }
+}


### PR DESCRIPTION
Missed setter for attribute name on line 93 causes the isCoreSchema check on line 117 to fail with NPE: fixed by using the Schema.toAttribute() helper method

Additional changes:
- removed many unnecessary checks by calling the validators before anything else