### PR TITLE
SCIIDDS-149: SAP extension schema cannot be recognized in path during the PATCH request

### DIFF
--- a/scimono-server/src/main/java/com/sap/scimono/callback/schemas/SchemasCallback.java
+++ b/scimono-server/src/main/java/com/sap/scimono/callback/schemas/SchemasCallback.java
@@ -159,7 +159,7 @@ public interface SchemasCallback {
   }
 
   static String addSchemaToPathIfNotExist(final String path, final String defaultSchema) {
-    if (Strings.isNullOrEmpty(path) || path.matches(SCHEMA_PATTERN.toString())) {
+    if (Strings.isNullOrEmpty(path) || path.startsWith(URN)) {
       return path;
     }
     return String.join(SCHEMA_URN_DELIMETER, defaultSchema, path);

--- a/scimono-server/src/main/java/com/sap/scimono/callback/schemas/SchemasCallback.java
+++ b/scimono-server/src/main/java/com/sap/scimono/callback/schemas/SchemasCallback.java
@@ -24,6 +24,7 @@ public interface SchemasCallback {
   String SCHEMA_URN_DELIMETER = ":";
   String ATTRIBUTE_VALUE_FILTER_OPENING = "[";
   String ATTRIBUTE_VALUE_FILTER_CLOSING = "]";
+  String URN = "urn:";
 
   /**
    * Returns the schema with the specified schemaId.
@@ -165,7 +166,7 @@ public interface SchemasCallback {
   }
 
   static boolean isAttributeNotationContainsSchema(final String fullAttrNotation) {
-    return fullAttrNotation.matches(SCHEMA_PATTERN.toString());
+    return fullAttrNotation.startsWith(URN);
   }
 
   default String appendSubAttributeToPath(final String fullAttributePath, final String subAttribute) {

--- a/scimono-server/src/main/java/com/sap/scimono/entity/validation/patch/PatchValidationFramework.java
+++ b/scimono-server/src/main/java/com/sap/scimono/entity/validation/patch/PatchValidationFramework.java
@@ -100,9 +100,7 @@ public class PatchValidationFramework {
     List<Validator<PatchOperation>> validators = new ArrayList<>();
 
     if(isOperationPathContainsValueFilter(path)){
-      if (!isAttributeNotationContainsSchema(path)) {
-        validators.add(new ValuePathAttributesValidator(requiredSchemas, schemaAPI, coreSchemaId));
-      }
+      validators.add(new ValuePathAttributesValidator(requiredSchemas, schemaAPI, coreSchemaId));
       validators.add(new ValuePathStructureValidator());
       validators.add(new ValuePathRestrictionsValidator());
     } else {

--- a/scimono-server/src/main/java/com/sap/scimono/entity/validation/patch/PatchValidationFramework.java
+++ b/scimono-server/src/main/java/com/sap/scimono/entity/validation/patch/PatchValidationFramework.java
@@ -100,7 +100,9 @@ public class PatchValidationFramework {
     List<Validator<PatchOperation>> validators = new ArrayList<>();
 
     if(isOperationPathContainsValueFilter(path)){
-      validators.add(new ValuePathAttributesValidator(requiredSchemas, schemaAPI, coreSchemaId));
+      if (!isAttributeNotationContainsSchema(path)) {
+        validators.add(new ValuePathAttributesValidator(requiredSchemas, schemaAPI, coreSchemaId));
+      }
       validators.add(new ValuePathStructureValidator());
       validators.add(new ValuePathRestrictionsValidator());
     } else {

--- a/scimono-server/src/main/java/com/sap/scimono/filter/patch/ValuePathAttributesValidationVisitor.java
+++ b/scimono-server/src/main/java/com/sap/scimono/filter/patch/ValuePathAttributesValidationVisitor.java
@@ -130,12 +130,11 @@ public class ValuePathAttributesValidationVisitor extends QueryFilterVisitor<Voi
       String attributeName = pathContext.getText();
 
       SchemasCallback schemaAPI = valuePathValidator.getSchemaAPI();
-      if (SchemasCallback.isAttributeNotationContainsSchema(attributeName)) {
-        attributeName = schemaAPI.removeSchemaFromAttributeNotation(attributeName, valuePathValidator.getCoreSchemaId());
+      if (!SchemasCallback.isAttributeNotationContainsSchema(attributeName)) {
+        attributeName = schemaAPI.appendSubAttributeToPath(currentAttributePath, attributeName);
       }
 
-      String newCurrentAttributePath = schemaAPI.appendSubAttributeToPath(currentAttributePath, attributeName);
-      return ctx.valFilter().accept(new ValuePathAttributesValidationVisitor(valuePathValidator, operation, newCurrentAttributePath));
+      return ctx.valFilter().accept(new ValuePathAttributesValidationVisitor(valuePathValidator, operation, attributeName));
     }
   }
 }


### PR DESCRIPTION
When we put a schema in path, the API is not recognized the it: 
```json
{
    "Operations": [
        {
            "op": "replace",
            "path": "urn:ietf:params:scim:schemas:extension:sap:2.0:User:emails[value eq \"mark.johnson9@sap-test.de\"]",
            "value": [
                {
                    "value": "mark.johnson9@sap-test.de",
                    "primary": true
                }
            ]
        }
    ],
    "schemas": [
        "urn:ietf:params:scim:api:messages:2.0:PatchOp"
    ]
}
```

The returned error is "Attribute with name 'urn:ietf:params:scim:schemas:core:2.0:User:urn:ietf:params:scim:schemas:extension:sap:2.0:User:emails' does not exist" which is not correct.