### PR TITLE
Remove redundant `POST` request when creating user

### DIFF
--- a/scimono-compliance-tests/src/main/java/com/sap/scimono/scim/system/tests/UserOperationsHttpResponseCodeTest.java
+++ b/scimono-compliance-tests/src/main/java/com/sap/scimono/scim/system/tests/UserOperationsHttpResponseCodeTest.java
@@ -47,7 +47,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 public class UserOperationsHttpResponseCodeTest extends SCIMHttpResponseCodeTest {
   private static final Logger logger = LoggerFactory.getLogger(UserOperationsHttpResponseCodeTest.class);
 
-  @RegisterExtension
+  @RegisterExtension 
   UserClientScimResponseExtension resourceAwareUserRequest = UserClientScimResponseExtension.forClearingAfterEachExecutions(userRequest);
   
   private final UserFailSafeClient userFailSafeClient = resourceAwareUserRequest.getFailSafeClient();

--- a/scimono-compliance-tests/src/main/java/com/sap/scimono/scim/system/tests/UserOperationsHttpResponseCodeTest.java
+++ b/scimono-compliance-tests/src/main/java/com/sap/scimono/scim/system/tests/UserOperationsHttpResponseCodeTest.java
@@ -47,7 +47,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 public class UserOperationsHttpResponseCodeTest extends SCIMHttpResponseCodeTest {
   private static final Logger logger = LoggerFactory.getLogger(UserOperationsHttpResponseCodeTest.class);
 
-  @RegisterExtension 
+  @RegisterExtension
   UserClientScimResponseExtension resourceAwareUserRequest = UserClientScimResponseExtension.forClearingAfterEachExecutions(userRequest);
   
   private final UserFailSafeClient userFailSafeClient = resourceAwareUserRequest.getFailSafeClient();
@@ -69,10 +69,8 @@ public class UserOperationsHttpResponseCodeTest extends SCIMHttpResponseCodeTest
   @DisplayName("Test Create user without userName and verify Http status code: 400")
   @EnableOnUsersBackendState(state = EMPTY)
   public void testCreateUserWithoutUserName400() {
-    final User userToCreate = userFailSafeClient.create(new User.Builder().setDisplayName("testCreatUserWithoutUserName400").build());
-
     logger.info("Creating User without userName");
-    final SCIMResponse<User> scimResponse = resourceAwareUserRequest.createUser(userToCreate);
+    final SCIMResponse<User> scimResponse = resourceAwareUserRequest.createUser(new User.Builder().setDisplayName("testCreatUserWithoutUserName400").build());
     assertAll("Verify Create User Response", getResponseStatusAssertions(scimResponse, false, BAD_REQUEST));
   }
 


### PR DESCRIPTION
## What
Remove redundant `createUser` call in the `UserOperationsHttpResponseCodeTest.java`.
## Why
I believe this line is redundant, as we pass a user without a `userName` into the `userFailSafeClient.create()`. That creation will simply fail without running any assertions afterward. The `resourceAwareUserRequest.createUser()` part is actually testing use creation and asserting afterward. 

## Special notes for reviewers
Could you please trigger a new Scimono release after merging this PR? :thx: