### PR TITLE
adapt test for single user using hashtag as id

### DIFF
--- a/scimono-compliance-tests/src/main/java/com/sap/scimono/scim/system/tests/UserOperationsHttpResponseCodeTest.java
+++ b/scimono-compliance-tests/src/main/java/com/sap/scimono/scim/system/tests/UserOperationsHttpResponseCodeTest.java
@@ -115,12 +115,13 @@ public class UserOperationsHttpResponseCodeTest extends SCIMHttpResponseCodeTest
   }
 
   @Test
-  @DisplayName("Test Get all users with # instead of id and verify Http status code: 404")
-  public void testGetAllUsersHashTag404() {
+  @DisplayName("Test Get single user with # instead of id and verify Http status code: 404 or 400")
+  public void testGetSingleUserHashTag404or400() {
     logger.info("Fetching User with #");
     SCIMResponse<User> scimResponse = resourceAwareUserRequest.readSingleUser("#");
 
-    assertAll("Verify GET Response", getResponseStatusAssertions(scimResponse, false, NOT_FOUND));
+    assertEquals(false, scimResponse.isSuccess(), "Verify response is failure");
+    assertEquals(true, scimResponse.getStatusCode() == NOT_FOUND.getStatusCode() || scimResponse.getStatusCode() == BAD_REQUEST.getStatusCode(), "Verify status code");
   }
 
   @Test


### PR DESCRIPTION
In [rfc](https://www.rfc-editor.org/rfc/rfc7644) below case does not necessarily require 404 when trying to get user with id `#`.  In this case, the hashtag as user ID could also be considered bad request. 

Could you please check if this could be included in existing test case?  Certainly the name of the test case has been changed because it is actually getting single user instead of all users, i.e.: `resourceAwareUserRequest.readSingleUser("#")` ).  We could also keep the original one and add a different expecting status code 400, so that other stakeholder would not have a breaking change. 