### PR TITLE
Get custom schema fix

### DIFF
--- a/scimono-server/src/main/java/com/sap/scimono/callback/schemas/SchemasCallback.java
+++ b/scimono-server/src/main/java/com/sap/scimono/callback/schemas/SchemasCallback.java
@@ -193,7 +193,7 @@ public interface SchemasCallback {
   }
 
   static boolean isCustomSchema(final String schemaId) {
-    return schemaId.matches(SCHEMA_PATTERN.toString());
+    return !isCoreSchema(schemaId) && schemaId.matches(SCHEMA_PATTERN.toString());
   }
 
   static boolean isCoreSchema(final String schemaId) {

--- a/scimono-server/src/test/java/com/sap/scimono/api/UsersTest.java
+++ b/scimono-server/src/test/java/com/sap/scimono/api/UsersTest.java
@@ -1,20 +1,52 @@
 package com.sap.scimono.api;
 
-import com.sap.scimono.SCIMApplication;
-import com.sap.scimono.exception.InvalidInputException;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.UUID;
+
+import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mockito;
 
-import java.util.UUID;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.sap.scimono.SCIMApplication;
+import com.sap.scimono.callback.schemas.SchemasCallback;
+import com.sap.scimono.callback.users.UsersCallback;
+import com.sap.scimono.entity.patch.PatchBody;
+import com.sap.scimono.entity.patch.PatchOperation;
+import com.sap.scimono.exception.InvalidInputException;
 
 public class UsersTest {
 
   private Users users;
 
+  private ObjectMapper mapper;
+  private SchemasCallback schemasCallbackMock = Mockito.mock(SchemasCallback.class, Mockito.CALLS_REAL_METHODS);
+  private UsersCallback usersCallbackMock = Mockito.mock(UsersCallback.class, Mockito.CALLS_REAL_METHODS);
+
+  ArgumentCaptor<String> userIdCaptor = ArgumentCaptor.forClass(String.class);
+  ArgumentCaptor<PatchBody> patchBodyCaptor = ArgumentCaptor.forClass(PatchBody.class);
+  private final String PATCH_OP_SCHEMA = "urn:ietf:params:scim:api:messages:2.0:PatchOp";
+
   @Before
   public void setup() {
+    mapper = new ObjectMapper();
     SCIMApplication scimApplication = new SCIMApplication() {
 
+      @Override
+      public SchemasCallback getSchemasCallback() {
+        return schemasCallbackMock;
+      }
+
+      @Override
+      public UsersCallback getUsersCallback() {
+        return usersCallbackMock;
+      }
     };
     users = new Users(scimApplication, null);
   }
@@ -29,6 +61,37 @@ public class UsersTest {
   public void testPatchUserWithEmptyBody() {
     String userId = String.valueOf(UUID.randomUUID());
     users.patchUser(userId, null);
+  }
+
+  @Test
+  public void testPatchUserActivate() throws JsonProcessingException {
+    Mockito.doNothing().when(usersCallbackMock).patchUser(Mockito.any(), Mockito.any(), Mockito.any());
+    Mockito.doReturn(new ArrayList<>()).when(schemasCallbackMock).getCustomSchemas();
+    String userId = String.valueOf(UUID.randomUUID());
+    Set<String> schemas = new HashSet<>();
+    schemas.add(PATCH_OP_SCHEMA);
+
+
+    JsonNode valueTrue = getValueTrue();
+    PatchOperation patchOperation1 = new PatchOperation.Builder()
+        .setOp(PatchOperation.Type.ADD)
+        .setPath("active")
+        .setValue(valueTrue)
+        .build();
+    PatchBody patchBody = new PatchBody.Builder()
+            .addOperation(patchOperation1)
+            .setSchemas(schemas)
+            .build();
+    users.patchUser(userId, patchBody);
+
+    Mockito.verify(usersCallbackMock).patchUser(userIdCaptor.capture(), patchBodyCaptor.capture(), Mockito.any());
+    Assert.assertEquals(userId, userIdCaptor.getValue());
+    Assert.assertEquals(patchBody, patchBodyCaptor.getValue());
+  }
+
+  private JsonNode getValueTrue() throws JsonProcessingException {
+    JsonNode boolValue = mapper.readTree("true");
+    return boolValue;
   }
 
 }


### PR DESCRIPTION
The custom schema is not only accepting custom schemas, it is accepting any syntactic valid schema.
That's why [these lines](https://github.com/SAP/scimono/blob/adebc03c26dbda55366849a477b4bcfb26e574e2/scimono-server/src/main/java/com/sap/scimono/callback/schemas/SchemasCallback.java#L37-L44) are effecting that every syntactic valid schema is handled like a custom schema. Core schemas will not be found.

In my understanding the core schemas are not custom schemas.