### PR TITLE
Removing override of a method with a default implementation.

### DIFF
--- a/scimono-server/src/main/java/com/sap/scimono/callback/schemas/DefaultSchemasCallback.java
+++ b/scimono-server/src/main/java/com/sap/scimono/callback/schemas/DefaultSchemasCallback.java
@@ -4,7 +4,6 @@ package com.sap.scimono.callback.schemas;
 import javax.ws.rs.WebApplicationException;
 import javax.ws.rs.core.Response;
 
-import com.sap.scimono.entity.schema.Attribute;
 import com.sap.scimono.entity.schema.Schema;
 
 import java.util.List;
@@ -34,11 +33,6 @@ public class DefaultSchemasCallback implements SchemasCallback {
 
   @Override
   public boolean isValidSchemaName(String schemaName) {
-    throw new WebApplicationException(Response.Status.NOT_IMPLEMENTED);
-  }
-
-  @Override
-  public Attribute getAttribute(String path) {
     throw new WebApplicationException(Response.Status.NOT_IMPLEMENTED);
   }
 


### PR DESCRIPTION
The word "Default" in the "DefaultSchemasCallback.java" let me assume that I can derive classes from it to implement some method which are needed in my use case. The fact that getAttribute is overridden in the DefaultSchemasCallback.java leads to confusion and makes it even harder to make it work with a derived class.
I think it is better to just let the default method in the interface shining through.