### PR TITLE
From Adopt 1.8 to SapMachine 21

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -8,10 +8,11 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
-    - name: Set up JDK 1.8
-      uses: actions/setup-java@v1
+    - uses: actions/checkout@v4
+    - name: Set up JDK
+      uses: actions/setup-java@v4
       with:
-        java-version: 1.8
+        java-version: 21
+        distribution: 'sapmachine'
     - name: Build with Maven
       run: mvn -B package --file pom.xml


### PR DESCRIPTION
Hi Colleagues,

[SapMachine](https://sapmachine.io/) is now available with
actions/setup-java@v4
Created a PR to migrate from Adopt 1.8 to SapMachine 21
Regards Christian@SapMachine Team

PS: Optional: there are newer versions of actions/checkout@v2 wherefore I changed that to recent version 4. That change is not required to make this change to work.